### PR TITLE
Optional parameters

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Generate data
         run: |
           python imf-currencies.py
+          python imf-currencies.py --source=ENSA --target=XDR
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ This scraper runs nightly at 5am GMT on Github Actions.
 
 You can find the data in the gh-pages branch of this repository, or alternatively under:
 
-https://codeforiati.org/imf-exchangerates/imf_exchangerates.csv
+IMF Currencies converted to USD (end of month): https://codeforiati.org/imf-exchangerates/imf_exchangerates.csv <br />
+IMF Currencies converted to SDR (monthly average): https://codeforiati.org/imf-exchangerates/imf_exchangerates_ENSA_XDR.csv
 
 ## Notes on the data
 
@@ -38,6 +39,20 @@ pip3 install -r requirements.txt
 2. Run the scraper:
 ```
 python3 imf-currencies.py
+```
+
+There are two optional parameters, source and target. The table below describes the options. The default behaviour is using ENDE as the source, and USD as the target. It is worth noting that for all cases XDR is appended to the end of the dataset as a conversion to USD, as converting XDR to XDR does not make sense.
+
+| Data source description                              | Full source       | Example data | Source | Target |
+|------------------------------------------------------|-------------------|--------------|--------|--------|
+| National Currency per SDR, end of period             | ENSE_XDC_XDR_RATE | [SDR end](http://dataservices.imf.org/REST/SDMX_JSON.svc/CompactData/IFS/M.NL.ENSE_XDC_XDR_RATE)         | ENSE   | XDR    |
+| National Currency per SDR, average of period         | ENSA_XDC_XDR_RATE | [SDR average](http://dataservices.imf.org/REST/SDMX_JSON.svc/CompactData/IFS/M.NL.ENSA_XDC_XDR_RATE)         | ENSA   | XDR    |
+| Domestic currency per U.S. Dollar, end of period     | ENDE_XDC_USD_RATE | [USD end](http://dataservices.imf.org/REST/SDMX_JSON.svc/CompactData/IFS/M.NL.ENDE_XDC_USD_RATE)         | ENDE   | USD    |
+| Domestic currency per U.S. Dollar, average of period | ENDA_XDC_USD_RATE | [USD average](http://dataservices.imf.org/REST/SDMX_JSON.svc/CompactData/IFS/M.NL.ENDA_XDC_USD_RATE)         | ENDA   | USD    |
+
+A parameterized scraper can be called with, for example:
+```
+python3 imf-currencies.py --source=ENSA --target=XDR
 ```
 
 ## IMF Data License

--- a/imf-currencies.py
+++ b/imf-currencies.py
@@ -106,7 +106,7 @@ def write_monthly_exchange_rates(source, target):
                     rc = requests.get(country_url.format(country['@value'], source, target)).json()
                 except json.decoder.JSONDecodeError:
                     time.sleep(2)
-                    rc = requests.get(country_url.format(country['@value'])).json()
+                    rc = requests.get(country_url.format(country['@value'], source, target)).json()
             dataset = rc['CompactData']['DataSet']
             if countries_currencies.get(country['@value']):
                 currency_code = countries_currencies.get(country['@value'])

--- a/imf-currencies.py
+++ b/imf-currencies.py
@@ -84,6 +84,10 @@ def fix_date(_val):
 @click.command()
 @click.option('--source', default=DEFAULT_SOURCE, help='Data source. Options: ENSE (National Currency per SDR, end of period), ENSA (National Currency per SDR, average of period), ENDE (Domestic currency per target USD, end of period), ENDA (Domestic currency per target USD, average of period).')
 @click.option('--target', default=DEFAULT_TARGET, help='Conversion target, Options: XDR (combined with ENSE/ENSA source), USD (combined with ENDE, ENDA source).')
+def _write_monthly_exchange_rates(source, target):
+    write_monthly_exchange_rates(source, target)
+
+
 def write_monthly_exchange_rates(source, target):
     """ For each country, write out monthly exchange rate data.
     Using click to allow optional parameters source and target.
@@ -130,5 +134,5 @@ def write_monthly_exchange_rates(source, target):
             # IMF API is rate-limited and allows only 10 requests every 5 seconds
             time.sleep(0.75)
 
-
-write_monthly_exchange_rates()
+if __name__ == "__main__":
+    _write_monthly_exchange_rates()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests==2.25.1
 lxml==4.6.2
+click==8.0.1

--- a/test_imf-currencies.py
+++ b/test_imf-currencies.py
@@ -7,7 +7,7 @@ EXISTING_URL="https://codeforiati.org/imf-exchangerates/imf_exchangerates.csv"
 class TestIMFCurrencies:
 
     imf_currencies = __import__('imf-currencies')
-    imf_currencies.write_monthly_exchange_rates()
+    imf_currencies.write_monthly_exchange_rates(source='ENDE', target='USD')
 
 
     def test_row_numbers(self):

--- a/test_imf-currencies.py
+++ b/test_imf-currencies.py
@@ -7,6 +7,7 @@ EXISTING_URL="https://codeforiati.org/imf-exchangerates/imf_exchangerates.csv"
 class TestIMFCurrencies:
 
     imf_currencies = __import__('imf-currencies')
+    imf_currencies.write_monthly_exchange_rates()
 
 
     def test_row_numbers(self):

--- a/test_imf-currencies.py
+++ b/test_imf-currencies.py
@@ -7,7 +7,6 @@ EXISTING_URL="https://codeforiati.org/imf-exchangerates/imf_exchangerates.csv"
 class TestIMFCurrencies:
 
     imf_currencies = __import__('imf-currencies')
-    imf_currencies.write_monthly_exchange_rates()
 
 
     def test_row_numbers(self):


### PR DESCRIPTION
Hi guys, 

As discussed in #1, I have provided a more generic approach to the currency scraping.

- Used click to allow optional parameters, defaulting to the old behaviour and collecting the selected rates, with `--help` available.
- Filename changes based on the selected parameters, default remains the same, an example use case with `XDR monthly averages` results in the filename `imf_exchangerates_ENSA_XDR.csv`.
- Added a line to the pythonapp.yml to export the dataset in the format the DSv2 would like to see, as per the ticket. Also added this information to the README.md (Based on the assumption that this would automagically spawn that link due to the deploy step).
- Added additional information about these optional parameters to the README.

[This google drive link](https://drive.google.com/file/d/1PFwQXfuBpj9fuIPxFPmsITyLKfZlXDls/view?usp=sharing) contains a .zip with two generated .csv files using `python imf-currencies.py` and `python imf-currencies.py --source=ENSA --target=XDR`

If there are any changes you would like to see to this please let me know!

Edit: also separated the work into several commits for easy cherry-picking or discarding.