### PR TITLE
Add tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  test:
+    name: Run tests
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - uses: actions/cache@v2
+      name: Cache dependencies
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('requirements_dev.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip wheel
+        pip install -r requirements_dev.txt
+    - name: Run tests
+      run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ pyenv
 *.sublime-*
 output
 .DS_Store
+__pycache__

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+
+pytest==6.2.4

--- a/test_imf-currencies.py
+++ b/test_imf-currencies.py
@@ -1,0 +1,44 @@
+import csv
+import re
+from urllib.request import Request, urlopen
+
+EXISTING_URL="https://codeforiati.org/imf-exchangerates/imf_exchangerates.csv"
+
+class TestIMFCurrencies:
+
+    imf_currencies = __import__('imf-currencies')
+
+
+    def test_row_numbers(self):
+        """
+        Check that running this code outputs the same
+        number of lines as were previously generated.
+        This will sometimes lead to some false negatives,
+        given that the data is updated frequently.
+        """
+        request = Request(EXISTING_URL)
+        existing_csv_len = len(urlopen(request).readlines())
+
+        with open("output/imf_exchangerates.csv", "r") as input_csv:
+            new_csv_len = len(input_csv.readlines())
+            assert new_csv_len == existing_csv_len
+
+
+    def _test_row_contents(self):
+        """
+        Confirm that every row has the correct contents.
+        NB this doesn't work at the moment due to bugs, but
+        it should eventually pass.
+        """
+        with open("output/imf_exchangerates.csv", "r") as input_csv:
+            reader = csv.DictReader(input_csv)
+            for i, row in enumerate(reader):
+                try:
+                    assert re.match(r"(\d{4})-(\d{2})-(\d{2})", row['Date'])
+                    assert re.match(r"(\d+\.*\d*)", row['Rate'])
+                    assert re.match(r"(\w+)", row['Currency'])
+                    assert re.match(r"(\w+)", row['Frequency'])
+                    assert re.match(r"(\w+)", row['Source'])
+                except AssertionError as e:
+                    print("Error on line {}, error was {}".format(i, e))
+                    raise e


### PR DESCRIPTION
Sets up a simple test framework. Currently this is a bit slow and takes ~5 minutes to complete, because it runs the full download and data generation process and just confirms that the total number of rows is identical as the data previously downloaded.