### PR TITLE
Update scraper to use the new IMF API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,18 +5,12 @@ jobs:
     name: Run tests
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+    - uses: actions/checkout@v5
+    - name: Set up Python 3.13
+      uses: actions/setup-python@v6
       with:
-        python-version: 3.9
-    - uses: actions/cache@v2
-      name: Cache dependencies
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('requirements_dev.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
+        python-version: 3.13
+        cache: pip
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip wheel

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -11,13 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
       - name: Set up Python 3.13
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.13
+          cache: pip
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## IMF Currency Rates against the U.S. Dollar
 
-This simple scraper creates a dataset of historical IMF exchange rates to the U.S. Dollar for 168 currencies. Data comes from the [IMF's International Financial Statistics](https://data.imf.org/?sk=4C514D48-B6BA-49ED-8AB9-52B0C1A0179B).
+This simple scraper creates a dataset of historical IMF exchange rates to the U.S. Dollar for 168 currencies. Data comes from the [IMF's International Financial Statistics](https://data.imf.org/en/datasets/IMF.STA:ER).
 
 This scraper runs nightly at 5am GMT on Github Actions.
 
@@ -20,7 +20,7 @@ It appears that the IMF API uses the ISO 3166 Alpha-2 code for each country, whi
 
 Currencies may change from time to time. Though it is difficult to be 100% sure about this from the available documentation on the API, it appears that all of the values are in each country's most recent currency.
 
-For example: according to [the IMF's Metadata PDF document for this dataset](https://data.imf.org/api/document/download?key=62969181), in January 1, 2005, Turkey introduced the New Turkish Lira (TRY), equivalent to 1,000,000 Turkish Lira. However, there does not appear to be any major change in the rate against the USD around that time.
+For example: according to [the IMF's Metadata PDF document for this dataset](https://data.imf.org/-/media/iData/External-Storage/Documents/7F74AA6D71D2438285DBAC19451D7F7C/en/Metadata-Exchange-Rate-databaseCountry-notesOctober-2025.pdf), in January 1, 2005, Turkey introduced the New Turkish Lira (TRY), equivalent to 1,000,000 Turkish Lira. However, there does not appear to be any major change in the rate against the USD around that time.
 
 ### Euro-area countries
 
@@ -46,10 +46,10 @@ There are two optional parameters, source and target. The table below describes 
 
 | Data source description                              | Full source       | Example data | Source | Target |
 |------------------------------------------------------|-------------------|--------------|--------|--------|
-| National Currency per SDR, end of period             | ENSE_XDC_XDR_RATE | [SDR end](http://dataservices.imf.org/REST/SDMX_JSON.svc/CompactData/IFS/M.NL.ENSE_XDC_XDR_RATE)         | ENSE   | XDR    |
-| National Currency per SDR, average of period         | ENSA_XDC_XDR_RATE | [SDR average](http://dataservices.imf.org/REST/SDMX_JSON.svc/CompactData/IFS/M.NL.ENSA_XDC_XDR_RATE)         | ENSA   | XDR    |
-| Domestic currency per U.S. Dollar, end of period     | ENDE_XDC_USD_RATE | [USD end](http://dataservices.imf.org/REST/SDMX_JSON.svc/CompactData/IFS/M.NL.ENDE_XDC_USD_RATE)         | ENDE   | USD    |
-| Domestic currency per U.S. Dollar, average of period | ENDA_XDC_USD_RATE | [USD average](http://dataservices.imf.org/REST/SDMX_JSON.svc/CompactData/IFS/M.NL.ENDA_XDC_USD_RATE)         | ENDA   | USD    |
+| National Currency per SDR, end of period             | ENSE_XDC_XDR_RATE | [SDR end](https://api.imf.org/external/sdmx/3.0/data/dataflow/IMF.STA/ER/%2B/*.XDC_XDR.EOP_RT.M?attributes=SCALE)         | ENSE   | XDR    |
+| National Currency per SDR, average of period         | ENSA_XDC_XDR_RATE | [SDR average](https://api.imf.org/external/sdmx/3.0/data/dataflow/IMF.STA/ER/%2B/*.XDC_XDR.PA_RT.M?attributes=SCALE)         | ENSA   | XDR    |
+| Domestic currency per U.S. Dollar, end of period     | ENDE_XDC_USD_RATE | [USD end](https://api.imf.org/external/sdmx/3.0/data/dataflow/IMF.STA/ER/%2B/*.XDC_USD.EOP_RT.M?attributes=SCALE)         | ENDE   | USD    |
+| Domestic currency per U.S. Dollar, average of period | ENDA_XDC_USD_RATE | [USD average](https://api.imf.org/external/sdmx/3.0/data/dataflow/IMF.STA/ER/%2B/*.XDC_USD.PA_RT.M?attributes=SCALE)         | ENDA   | USD    |
 
 A parameterized scraper can be called with, for example:
 ```

--- a/imf-currencies.py
+++ b/imf-currencies.py
@@ -1,179 +1,218 @@
-#!/usr/bin/env python
-# coding: utf-8
+import calendar
+import csv
+import datetime
+from functools import lru_cache
+from io import BytesIO
+import json
+import os
 
 import click
-import requests
-import json
-import csv
-import time
 from lxml import etree
-from io import BytesIO
-import os
-import datetime
-import calendar
+import requests
 
 
-IMF_CL_AREA_URL="http://dataservices.imf.org/REST/SDMX_JSON.svc/CodeList/CL_AREA_IFS_2019M03"
-# FYI SEE ALSO
-# http://dataservices.imf.org/REST/SDMX_JSON.svc/DataStructure/IFS_2019M03
-DEFAULT_FREQ = 'M'
-DEFAULT_SOURCE = 'ENDE'
-DEFAULT_TARGET = 'USD'
-FIELDNAMES=['Date', 'Rate', 'Currency', 'Frequency', 'Source', 'Country code', 'Country']
-ISO_COUNTRY_URL = "https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/lists/list-one.xml"
-COUNTRY_CODELIST = "https://codelists.codeforiati.org/api/json/en/Country.json"
-SLEEP_TIME = 0.25
-
-# Eurozone countries need to have the old currency code specified manually.
-with open('source/eurozone.csv', 'r') as eurozone_file:
-    csvreader = csv.DictReader(eurozone_file)
-    EUROZONE_COUNTRIES = dict([(row['country_name'], {'code': row['country_code'], 'currency': row['currency_code']}) for row in csvreader])
-
-# Unfortunately, the XML file with currency codes which
-# ISO makes available does not use country codes and does not always
-# exactly match ISO's name for the country.
-with open('source/missing.csv', 'r') as missing_file:
-    csvreader = csv.DictReader(missing_file)
-    MISSING = dict([(row['country_name'], {'code': row['country_code'], 'currency': row['currency_code']}) for row in csvreader])
-
-# Gradually back off to allow for IMF rate limiting
-# IMF API is rate-limited and allows only 10 requests every 5 seconds
-# https://datahelp.imf.org/knowledgebase/articles/630877-api
-def get_request(url, sleep_time, attempt=1):
-    # If sleep time has crept up to 10 seconds, looks like it isn't going
-    # to work this time.
-    if attempt >1:
-        print("Attempt {}.".format(attempt))
-    if sleep_time >= 60:
-        raise Exception("Unable to retrieve url {} even after waiting for {} seconds.".format(
-            url, sleep_time))
-    # Sleep longer the more attempts there are.
-    time.sleep(sleep_time * attempt)
-    try:
-        json_data = requests.get(url).json()
-    except json.decoder.JSONDecodeError:
-        sleep_time += 0.5
-        print("Slowing down to {} seconds to handle rate limiting.".format(sleep_time))
-        return get_request(url, sleep_time, attempt+1)
-    return json_data, sleep_time
+DEFAULT_FREQ = "M"
+DEFAULT_SOURCE = "ENDE"
+DEFAULT_TARGET = "USD"
+FIELDNAMES = ["Date", "Rate", "Currency", "Frequency", "Source", "Country code", "Country"]
 
 
-# ## Get country codes and exchange rates and map them together
-
-country_request, _ = get_request(COUNTRY_CODELIST, SLEEP_TIME)
-country_r = country_request['data']
-iso_country_r = BytesIO(requests.get(ISO_COUNTRY_URL).text.encode("utf-8"))
-iso_exchange_rates = etree.parse(iso_country_r).xpath("//CcyNtry")
-
-def get_countries_codes(update_eurozone=True, update_missing=True):
-    country_codes = dict(map(lambda c: (c['name'].upper(), {'code': c['code']}), country_r))
-    for country_rate in iso_exchange_rates:
-        country = country_rate.find('CtryNm')
-        currency = country_rate.find('Ccy')
-        currency_name = country_rate.find('CcyNm')
-        if (country == None) or (currency == None): continue
-        if currency_name.get('IsFund') is not None: continue
-        if country_codes.get(country.text):
-            country_codes[country.text]['currency'] = currency.text
-    if update_eurozone:
-        country_codes.update(EUROZONE_COUNTRIES)
-    if update_missing:
-        country_codes.update(MISSING)
-
-    countries_currencies = dict(map(lambda c: (c.get('code'), c.get('currency')), country_codes.values()))
-    countries_currencies['XDR'] = 'XDR'
-    return countries_currencies
-countries_currencies = get_countries_codes()
-
-
-# Optionally, check for countries with missing codes
-#dict(filter(lambda code: code[1].get('currency')==None, country_codes.items()))
-
-
-# ## Get list of recognised countries in this dataset from the IMF website
-
-
-r_imf_countries, _ = get_request(IMF_CL_AREA_URL, SLEEP_TIME)
-imf_countries = r_imf_countries['Structure']['CodeLists']['CodeList']['Code']
-
-# We also want to get XDR:USD, so we cheekily include this here.
-imf_countries.append({'@value': 'XDR', 'Description': {'#text': 'IMF Special Drawing Rights'}})
-
-
-def fix_date(_val):
-    if len(_val.split("-")) == 2:
-        _year, _month = _val.split("-")
+def fix_date(date_val):
+    date_val = date_val.replace("-M", "-")
+    if len(date_val.split("-")) == 2:
+        year, month = date_val.split("-")
     else:
-        _year, _month = _val, 12
-    _year, _month = int(_year), int(_month)
-    last_day_of_month = calendar.monthrange(_year, _month)[1]
-    return datetime.date(_year, _month, last_day_of_month).isoformat()
+        year, month = date_val, 12
+    year, month = int(year), int(month)
+    last_day_of_month = calendar.monthrange(year, month)[1]
+    return datetime.date(year, month, last_day_of_month).isoformat()
+
+
+def get_names_to_currencies():
+    ISO_COUNTRY_URL = "https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/lists/list-one.xml"
+    iso_country_r = BytesIO(requests.get(ISO_COUNTRY_URL).text.encode("utf-8"))
+    iso_exchange_rates = etree.parse(iso_country_r).xpath("//CcyNtry")
+    return {
+        country_rate.find("CtryNm").text.upper(): country_rate.find("Ccy").text
+        for country_rate in iso_exchange_rates
+        if country_rate.find("CtryNm") is not None
+        and country_rate.find("Ccy") is not None
+        and country_rate.find("CcyNm").get("IsFund") is None
+    }
+
+
+@lru_cache
+def get_eurozone_countries():
+    with open("source/eurozone.csv", "r") as f:
+        reader = csv.DictReader(f)
+        return list(reader)
+
+
+@lru_cache
+def get_missing_countries():
+    with open("source/missing.csv", "r") as f:
+        return list(csv.DictReader(f))
+
+
+@lru_cache
+def get_country_code_2_to_names():
+    COUNTRY_CODELIST = "https://codelists.codeforiati.org/api/json/en/Country.json"
+    country_request = requests.get(COUNTRY_CODELIST).json()
+    return {
+        c["code"]: c["name"]
+        for c in country_request["data"]
+    }
+
+
+def get_country_code_2_to_currencies(update_eurozone=True, update_missing=True):
+    country_name_to_currency = get_names_to_currencies()
+    country_code_2_to_names = get_country_code_2_to_names()
+    countries_to_currencies = {
+        code: country_name_to_currency.get(name.upper())
+        for code, name in country_code_2_to_names.items()
+    }
+    if update_eurozone:
+        eurozone_countries = get_eurozone_countries()
+        countries_to_currencies.update({
+            eurozone_country["country_code_2"]: eurozone_country["currency_code"]
+            for eurozone_country in eurozone_countries
+        })
+    if update_missing:
+        missing_countries = get_missing_countries()
+        countries_to_currencies.update({
+            missing_country["country_code_2"]: missing_country["currency_code"]
+            for missing_country in missing_countries
+        })
+    countries_to_currencies["XDR"] = "XDR"
+    return countries_to_currencies
+
+
+def get_country_code_3_to_code_2s():
+    region_m49_data = requests.get("https://codelists.codeforiati.org/api/json/en/RegionM49.json").json()
+    code_3_to_code_2s = {
+        c["codeforiati:iso-alpha-3-code"]: c["codeforiati:iso-alpha-2-code"]
+        for c in region_m49_data["data"]
+    }
+    code_3_to_code_2s.update({
+        missing_country["country_code_3"]: missing_country["country_code_2"]
+        for missing_country in get_missing_countries()
+    })
+    code_3_to_code_2s["XDR"] = "XDR"
+    return code_3_to_code_2s
+
+
+def get_country_code_3_to_names():
+    IMF_CL_AREA_URL = "https://api.imf.org/external/sdmx/3.0/structure/codelist/IMF.STA/CL_ER_COUNTRY_PUB"
+    r_imf_countries = requests.get(IMF_CL_AREA_URL).json()
+    lookup = {c["id"]:  c["name"] for c in r_imf_countries["data"]["codelists"][0]["codes"]}
+    lookup["XDR"] = "IMF Special Drawing Rights"
+    return lookup
+
+
+def get_exchange_rates(frequency, source, target, country="*", base="XDC"):
+    if source[-1] == "E":
+        # End of period
+        transformation = "EOP_RT"
+    else:
+        # Average of period
+        transformation = "PA_RT"
+    url = f"https://api.imf.org/external/sdmx/3.0/data/dataflow/IMF.STA/ER/%2B/{country}.{base}_{target}.{transformation}.{frequency}?attributes=SCALE"
+    response = requests.get(url)
+    rc = response.json()
+    country_codes_3 = [c["id"] for c in rc["data"]["structures"][0]["dimensions"]["series"][0]["values"]]
+    time_periods = [c["value"] for c in rc["data"]["structures"][0]["dimensions"]["observation"][0]["values"]]
+    exchange_rates = {}
+    for series_id, series in rc["data"]["dataSets"][0]["series"].items():
+        country_code_3 = country_codes_3[int(series_id.split(":", 1)[0])]
+        if "observations" not in series:
+            print(f"No exchange rate data found for country code: {country_code_3}")
+            continue
+        exchange_rates[country_code_3] = sorted([
+            (time_periods[int(time_period_id)], value[0])
+            for time_period_id, value in series["observations"].items()
+        ])
+    return exchange_rates
+
 
 def write_countries_currencies():
-    with open('output/currencies_pre_eurozone.json', 'w') as countries_currencies_json:
-        json.dump(get_countries_codes(), countries_currencies_json)
-    with open('output/currencies.json', 'w') as countries_currencies_json:
-        json.dump(get_countries_codes(update_eurozone=False), countries_currencies_json)
+    os.makedirs("output", exist_ok=True)
+    with open("output/currencies_pre_eurozone.json", "w") as countries_currencies_json:
+        json.dump(get_country_code_2_to_currencies(), countries_currencies_json)
+
+    with open("output/currencies.json", "w") as countries_currencies_json:
+        json.dump(get_country_code_2_to_currencies(update_eurozone=False), countries_currencies_json)
 
 
-# ## For each country, write out monthly exchange rate data
+def get_rates_and_country_data(frequency, source, target, country="*", base="XDC"):
+    exchange_rates = get_exchange_rates(frequency, source, target, country, base)
+    country_code_3_to_code_2s = get_country_code_3_to_code_2s()
+    country_code_2_to_currencies = get_country_code_2_to_currencies()
+    country_code_3_to_names = get_country_code_3_to_names()
+    data = []
+    for country_code_3, exchange_rates in exchange_rates.items():
+        if base == "XDR":
+            country_code_3 = "XDR"
+        country_name = country_code_3_to_names.get(country_code_3)
+        country_code_2 = country_code_3_to_code_2s.get(country_code_3)
+        currency_code = country_code_2_to_currencies.get(country_code_2)
+        data.append({
+            "rates": exchange_rates,
+            "currency": currency_code,
+            "frequency": frequency,
+            "country_code_3": country_code_3,
+            "country_code_2": country_code_2,
+            "country_name": country_name,
+        })
+    return data
+
+
+def write_data_for_country(frequency, source, target, country, writer):
+    data = get_rates_and_country_data(frequency, source, target, country)
+    if country == "*":
+        if target == "USD":
+            data += get_rates_and_country_data(frequency, source, target, "USA", "XDR")
+        data = sorted(data, key=lambda x: x["country_name"])
+
+    for country_data in data:
+        for time_period, rate in country_data["rates"]:
+            writer.writerow({
+                "Date": fix_date(time_period),
+                "Rate": rate,
+                "Currency": country_data["currency"],
+                "Frequency": country_data["frequency"],
+                "Source": "IMF",
+                "Country code": country_data["country_code_2"],
+                "Country": country_data["country_name"],
+            })
+
+
+def write_monthly_exchange_rates(frequency, source, target):
+    fname_suffix = (
+        ""
+        if source is DEFAULT_SOURCE and target is DEFAULT_TARGET
+        else "_{}_{}_{}".format(frequency, source, target)
+    )
+    output_filename = f"output/imf_exchangerates{fname_suffix}.csv"
+    os.makedirs("output", exist_ok=True)
+    with open(output_filename, "w") as f:
+        writer = csv.DictWriter(f, FIELDNAMES)
+        writer.writeheader()
+
+        write_data_for_country(frequency, source, target, "*", writer)
+
+
 @click.command()
-@click.option('--freq', default=DEFAULT_FREQ, help='Frequency of rates. Options: A (Annual), B (Biannual), Q (Quarterly), M (Monthly), W (Weekly), D (Daily).')
-@click.option('--source', default=DEFAULT_SOURCE, help='Data source. Options: ENSE (National Currency per SDR, end of period), ENSA (National Currency per SDR, average of period), ENDE (Domestic currency per target USD, end of period), ENDA (Domestic currency per target USD, average of period).')
-@click.option('--target', default=DEFAULT_TARGET, help='Conversion target, Options: XDR (combined with ENSE/ENSA source), USD (combined with ENDE, ENDA source).')
+@click.option("--freq", default=DEFAULT_FREQ, help="Frequency of rates. Options: A (Annual), Q (Quarterly), M (Monthly).", type=click.Choice(["A", "Q", "M"], case_sensitive=False))
+@click.option("--source", default=DEFAULT_SOURCE, help="Data source. Options: ENSE (National Currency per SDR, end of period), ENSA (National Currency per SDR, average of period), ENDE (Domestic currency per target USD, end of period), ENDA (Domestic currency per target USD, average of period).", type=click.Choice(["ENSE", "ENSA", "ENDE", "ENDA"], case_sensitive=False))
+@click.option("--target", default=DEFAULT_TARGET, help="Conversion target, Options: XDR (combined with ENSE/ENSA source), USD (combined with ENDE, ENDA source).", type=click.Choice(["XDR", "USD"], case_sensitive=False))
 def _write_monthly_exchange_rates(freq, source, target):
+    if target == "USD":
+        assert source[-2] == "D", "Expected source to be ENDE or ENDA for USD target."
+    else:
+        assert source[-2] == "S", "Expected source to be ENSA or ENSE for XDR target."
     write_monthly_exchange_rates(freq, source, target)
     write_countries_currencies()
 
-
-def write_monthly_exchange_rates(freq, source, target):
-    """ For each country, write out monthly exchange rate data.
-    Using click to allow optional parameters source and target.
-    """
-    output_file = 'output/imf_exchangerates{}.csv'.format("" if source is DEFAULT_SOURCE and target is DEFAULT_TARGET
-                                                          else "_{}_{}_{}".format(freq, source, target))
-    os.makedirs('output', exist_ok=True)
-    with open(output_file, "w") as output_csv:  # Include format statement to catch the default
-        writer = csv.DictWriter(output_csv, FIELDNAMES)
-        writer.writeheader()
-        sleep_time = SLEEP_TIME
-        for i, country in enumerate(imf_countries):
-            sleep_time = write_data_for_country(writer, country, sleep_time, freq, source, target)
-
-
-def write_data_for_country(writer, country, sleep_time, freq, source, target):
-    country_url = 'http://dataservices.imf.org/REST/SDMX_JSON.svc/CompactData/IFS/{}.{}.{}_XDC_{}_RATE'
-    xdr_url = 'http://dataservices.imf.org/REST/SDMX_JSON.svc/CompactData/IFS/{}.US.ESD{}_XDR_USD_RATE'
-    print("Getting data for {}".format(country))
-    # There is a different API URL for XDR
-    # Monthly average/end of period for consistency
-    if country['@value'] == 'XDR':
-        rc, sleep_time = get_request(xdr_url.format(freq, source[-1]),
-            sleep_time)
-    else:
-        rc, sleep_time = get_request(country_url.format(freq, country['@value'], source, target),
-            sleep_time)
-    dataset = rc['CompactData']['DataSet']
-    if countries_currencies.get(country['@value']):
-        currency_code = countries_currencies.get(country['@value'])
-    else:
-        currency_code = ''
-    if 'Series' in dataset:
-        exchange_rates_data = dataset['Series']['Obs']
-        if type(exchange_rates_data) != list: return sleep_time
-        for row in exchange_rates_data:
-            if '@OBS_VALUE' not in row: return sleep_time  # Safety for possible missing data for ENSA and ENDA.
-            if row['@OBS_VALUE'] == "0": return sleep_time # Fixes issue with MM Monthly rates suddenly set to 0 for 2021-10 onwards
-            writer.writerow({
-                'Date': fix_date(row['@TIME_PERIOD']),
-                'Rate': row['@OBS_VALUE'],
-                'Currency': currency_code,
-                'Frequency': freq,
-                'Source': 'IMF',
-                'Country code': country['@value'],
-                'Country': country['Description']['#text'],
-            })
-    return sleep_time
 
 if __name__ == "__main__":
     _write_monthly_exchange_rates()

--- a/imf-currencies.py
+++ b/imf-currencies.py
@@ -18,9 +18,11 @@ FIELDNAMES = ["Date", "Rate", "Currency", "Frequency", "Source", "Country code",
 
 
 def fix_date(date_val):
-    date_val = date_val.replace("-M", "-")
-    if len(date_val.split("-")) == 2:
-        year, month = date_val.split("-")
+    if "M" in date_val:
+        year, month = date_val.split("-M")
+    elif "Q" in date_val:
+        year, quarter = date_val.split("-Q")
+        month = int(quarter) * 3
     else:
         year, month = date_val, 12
     year, month = int(year), int(month)

--- a/source/eurozone.csv
+++ b/source/eurozone.csv
@@ -1,4 +1,4 @@
-country_name,country_code,currency_code
+country_name,country_code_2,currency_code
 AUSTRIA,AT,ATS
 BELGIUM,BE,BEF
 CROATIA,HR,HRD
@@ -12,7 +12,6 @@ GERMANY,DE,DEM
 GREECE,GR,GRD
 IRELAND,IE,IEP
 ITALY,IT,ITL
-KOSOVO,XK,EUR
 LATVIA,LV,LVL
 LITHUANIA,LT,LTL
 LUXEMBOURG,LU,LUF

--- a/source/missing.csv
+++ b/source/missing.csv
@@ -1,18 +1,20 @@
-country_name,country_code,currency_code
-EUROZONE,U2,EUR
-KOREA (THE DEMOCRATIC PEOPLE'S REPUBLIC OF),KP,KPW
-LAO PEOPLE'S DEMOCRATIC REPUBLIC (THE),LA,LAK
-NETHERLANDS ANTILLES,AN,NLG
-SYRIAN ARAB REPUBLIC (THE),SY,SYP
-"TANZANIA, THE UNITED REPUBLIC OF",TZ,TZS
-Curacao & St. Maarten,1C_355,ANG
-Former Czechoslovakia,CSH,CSJ
-East Germany,DE2,DDM
-Former U.S.S.R.,SUH,SUR
-Yemen Arab Rep.,1C_473,YDD
-"Yemen, P.D. Rep.",1C_459,YDD
-Former Yugoslavia,YUC,YUN
-Eastern Caribbean Currency Union,5Y,XCD
-WAEMU (West African Economic and Monetary Union),7A,XOF
-Turkey,TR,TRY
-CEMAC,5X,XAF
+country_name,country_code_3,country_code_2,currency_code
+EUROZONE,G163,U2,EUR
+KOREA (THE DEMOCRATIC PEOPLE'S REPUBLIC OF),PRK,KP,KPW
+LAO PEOPLE'S DEMOCRATIC REPUBLIC (THE),LAO,LA,LAK
+NETHERLANDS ANTILLES,ANT,AN,NLG
+SYRIAN ARAB REPUBLIC (THE),SYR,SY,SYP
+"TANZANIA, THE UNITED REPUBLIC OF",TZA,TZ,TZS
+Curacao & St. Maarten,CWX,1C_355,ANG
+Former Czechoslovakia,CSK,CSH,CSJ
+East Germany,DDR,DE2,DDM
+Former U.S.S.R.,SUN,SUH,SUR
+Yemen Arab Rep.,YAR,1C_473,YDD
+"Yemen, P.D. Rep.",YMD,1C_459,YDD
+Former Yugoslavia,YUG,YUC,YUN
+Eastern Caribbean Currency Union,G309,5Y,XCD
+WAEMU (West African Economic and Monetary Union),G759,7A,XOF
+Turkey,TUR,TR,TRY
+CEMAC,G758,5X,XAF
+KOSOVO,KOS,XK,EUR
+Taiwan (Province of China),TWN,TW,TWD

--- a/source/missing.csv
+++ b/source/missing.csv
@@ -18,3 +18,4 @@ Turkey,TUR,TR,TRY
 CEMAC,G758,5X,XAF
 KOSOVO,KOS,XK,EUR
 Taiwan (Province of China),TWN,TW,TWD
+Benelux,G129,R1,BEF

--- a/test_imf-currencies.py
+++ b/test_imf-currencies.py
@@ -5,10 +5,9 @@ from urllib.request import Request, urlopen
 EXISTING_URL="https://codeforiati.org/imf-exchangerates/imf_exchangerates.csv"
 
 class TestIMFCurrencies:
-
-    imf_currencies = __import__('imf-currencies')
-    imf_currencies.write_monthly_exchange_rates(freq='M', source='ENDE', target='USD')
-
+    def setup_class(cls):
+        imf_currencies = __import__("imf-currencies")
+        imf_currencies.write_monthly_exchange_rates(frequency="M", source="ENDE", target="USD")
 
     def test_row_numbers(self):
         """
@@ -35,11 +34,11 @@ class TestIMFCurrencies:
             reader = csv.DictReader(input_csv)
             for i, row in enumerate(reader):
                 try:
-                    assert re.match(r"(\d{4})-(\d{2})-(\d{2})", row['Date'])
-                    assert re.match(r"(\d+\.*\d*)", row['Rate'])
-                    assert re.match(r"(\w+)", row['Currency'])
-                    assert re.match(r"(\w+)", row['Frequency'])
-                    assert re.match(r"(\w+)", row['Source'])
+                    assert re.match(r"(\d{4})-(\d{2})-(\d{2})", row["Date"])
+                    assert re.match(r"(\d+\.*\d*)", row["Rate"])
+                    assert re.match(r"(\w+)", row["Currency"])
+                    assert re.match(r"(\w+)", row["Frequency"])
+                    assert re.match(r"(\w+)", row["Source"])
                 except AssertionError as e:
                     print("Error on line {}, error was {}".format(i, e))
                     raise e


### PR DESCRIPTION
Fixes #19.

I’ve checked the output now, and have put together the following notes. Tl;dr I **think** it all looks fine!

---

### The order of the countries in the CSV is different

I don’t know how important this is. The countries didn’t appear to be sorted previously, whereas I’ve now sorted alphabetically by country name.

### Some of the country names are different

E.g. in the tests you’ll see that:
> Euro area (Member States and Institutions of the Euro Area) changing composition

…has changed to:
> Euro Area (EA)

These names come from the IMF country codelist – the URL and apparently also output of which has changed with the new API. These names are the same ones that [the IMF exchange rates data explorer](https://data.imf.org/en/Data-Explorer?datasetUrn=IMF.STA:ER(4.0.1)) is using, so I’m tempted to keep them.

A weird case of this, though, is **Benelux**… Data that was previously for “Belgo-Luxembourg Economic Union” (`R1` was the alpha-2 country code used by IMF) is now recorded as “Benelux” (`G129` is the alpha-3 country code used by IMF). This is weird because I don’t think these two regions are actually the same? (The latter is missing the small matter of the Netherlands!) Anyway, I’m not sure what currency or country code we should be using for Benelux. Previously we didn’t record a currency code, and we used `R1` for the country code. If we want to stick with `R1` for the country code, we’d need to add a row to missing.csv like so:

```csv
Benelux,G129,R1,
```

### The rates don’t always match

I’ve checked these, and in all cases it’s either:
1. a very very tiny discrepancy (e.g. you’ll see in the tests that 0.878425860857344 has changed to 0.8784258608573436 – a 4*10^-16 difference 🙃), or
2. a very recent adjustment (e.g. there are some larger adjustments, but they’re for recent months in 2025, or recent years where there’s only annual data).

I thought there were cases where the discrepancies were larger, but it looks like it was just hyperinflation related. If I compare relative differences instead of absolute, that goes away.

### Extra data

There are two extra countries in the output – Andorra (`AD`) and Liechtenstein (`LI`) – but they’re both currencies we have elsewhere anyway (i.e. EUR and CHF). I guess these weren’t available via the old IMF API.

There’s now monthly data for Vietnam (`VN`). It’s present in M_ENSA_XDR, and wasn’t previously.

There’s annual data for Sint Maarten (Dutch part) (`SX`), Moldova (`MD`) and Curaçao (`CW`). These are all present in A_ENDA_USD, and weren’t previously.

There’s also a bunch of recent annual datapoints for Iraq (`IQ`) from 2004-2024, and for Zimbabwe (`ZW`) from 2020-2024. These are in A_ENDA_USD. There’s a bunch of new monthly 2024/2025 datapoints for various countries including Russian Federation (`RU`); Ghana (`GH`) etc. I think all of this is to be expected.


### Missing data

For A_ENDA_USD, there are two data points for Kuwait (`KW`) that were present previously and are now missing (1990 and 1991). I guess this is Gulf war -related, and these were removed from the IMF API.

I’ve also deliberately excluded exchange rates from XDR to XDR (i.e. for ENSE and ENSA), because I think these were previously wrong (I think it may have been mistakenly showing XDR to USD).

### One currencies.json difference

“Heard Island and McDonald Islands” (`HM`) maps to AUD in currencies.json (and the pre-eurozone version) whereas before it mapped to null. I think this was a mistake previously, due to slight weirdness in the naming on the currencies codelist. But it doesn’t affect anything in the rates files.

### Other notes

Because the IMF API uses alpha-3, I needed to modify the structure of missing.csv, to add alpha-3 country codes as well.

I also needed to move Kosovo from eurozone.csv to missing.csv, and add Taiwan to missing.csv. Both these changes relate to the alpha-3 country code change, because neither of these regions are in the M49 codelist. If there’s a way to get alpha-2 country codes out of the IMF API, that would solve this, but I haven’t found it.

Because we make very few requests now (we hit the IMF API 3 times per run) I’ve removed all the rate limiting code. We could absolutely put it back, but I don’t think it’s really necessary.

There were two checks that I’ve removed, because I don’t *think* they’re necessary:
https://github.com/codeforIATI/imf-exchangerates/blob/bca62529245c783c131597240279e154433ab273/imf-currencies.py#L165-L166
(There are no unexpected zero values currently). If you think they’re needed, though, we can absolutely add them back in.